### PR TITLE
fix: bump versions and remove installation of 1 package from gh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, dev, github_actions ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, dev, github_actions ]
+    branches: [ main, dev ]
 
 jobs:
   Formatting:

--- a/workflow/envs/bsgenome.yml
+++ b/workflow/envs/bsgenome.yml
@@ -4,9 +4,10 @@ channels:
  - bioconda
  - defaults
 dependencies:
+ - r-base 4.3.1
  - r-tidyverse=2.0.0
  - r-devtools
- - bioconductor-biostrings=2.66.0
- - bioconductor-genomicfeatures=1.50.2
- - bioconductor-bsgenome=1.66.3
+ - bioconductor-biostrings=2.68.1
+ - bioconductor-genomicfeatures=1.52.1
+ - bioconductor-bsgenome=1.68.0
  

--- a/workflow/envs/design_guides.yml
+++ b/workflow/envs/design_guides.yml
@@ -4,11 +4,11 @@ channels:
  - bioconda
  - defaults
 dependencies:
+ - r-base 4.3.1
  - r-tidyverse=2.0.0
- - r-remotes
- - bioconductor-biostrings=2.66.0
- - bioconductor-genomicfeatures=1.50.2
- - bioconductor-crisprbase=1.2.0
- - bioconductor-crisprdesign=1.0.0
- - bioconductor-crisprbwa=1.2.0
- - bioconductor-crisprscore=1.2.0
+ - bioconductor-biostrings=2.68.1
+ - bioconductor-genomicfeatures=1.52.1
+ - bioconductor-crisprbase=1.4.0
+ - bioconductor-crisprdesign=1.2.0
+ - bioconductor-crisprbwa=1.4.0
+ - bioconductor-crisprscore=1.4.0

--- a/workflow/envs/visualize_guides.yml
+++ b/workflow/envs/visualize_guides.yml
@@ -3,8 +3,8 @@ channels:
  - conda-forge
  - defaults
 dependencies:
- - r-base=4.2.3
- - r-essentials=4.2
+ - r-base 4.3.1
+ - r-essentials=4.3
  - r-tidyverse=2.0.0
  - r-ggrepel=0.9.3
  - r-rstatix=0.7.2

--- a/workflow/scripts/design_guides.R
+++ b/workflow/scripts/design_guides.R
@@ -1,14 +1,5 @@
 # LOAD PACKAGES
 # ------------------------------
-
-# temporary fix to obtain latest version of crisprDesign from github
-# (currently not available in conda)
-packages <- installed.packages()
-cdesign_version <- packages[rownames(packages) == "crisprDesign", ]["Version"]
-if (cdesign_version == "1.0.0") {
-  remotes::install_github("https://github.com/crisprVerse/crisprDesign", quiet = TRUE)
-}
-
 suppressPackageStartupMessages({
   library(tidyverse)
   library(Biostrings)


### PR DESCRIPTION
- versions to R 4.3 and according bioconductor packages
- makes manual installation of R package cirsprDesign 1.2.0 from GH unnecessary as it is now available on BioC